### PR TITLE
Add message for 'undefined method `any?' for nil'

### DIFF
--- a/lib/match_json/matchers/include_json.rb
+++ b/lib/match_json/matchers/include_json.rb
@@ -55,10 +55,10 @@ module MatchJson
 
       def array_included?(actual, expected, nested, raise_error)
         expected.each do |value|
-          if (!actual.any? { |actual_value| equal_value?(actual_value, value, nested, false) })
+          if actual.nil? || (!actual.any? { |actual_value| equal_value?(actual_value, value, nested, false) })
             @failure_message = %Q("#{value}" was not found in\n )
             @failure_message << %Q("#{nested}"=>) if !nested.empty?
-            @failure_message << "#{actual}"
+            @failure_message << "#{actual.nil? ? "nil" : actual}"
 
             if raise_error
               throw(:match, false)

--- a/spec/match_json/matchers_spec.rb
+++ b/spec/match_json/matchers_spec.rb
@@ -32,6 +32,12 @@ describe "include_json" do
         expect(%Q({ "array" : [1, 2, 3] })).to include_json(%Q({ "array" : [5, 1] }))
       }.to fail_with(%Q("5" was not found in\n " > array"=>[1, 2, 3]))
     end
+
+    it 'fails with there is null instead of array' do
+      expect {
+        expect(%Q({ "array" : null })).to include_json(%Q({ "array" : [5] }))
+      }.to fail_with(%Q("5" was not found in\n " > array"=>nil))
+    end
   end
 
   context 'when array contains object' do


### PR DESCRIPTION
```
  1) include_json when object contains array fails with there null instead of array
     Failure/Error: expect {
       expected RSpec::Expectations::ExpectationNotMetError with "\"5\" was not found in\n \" > array\"=>[1, 2, 3]", got #<NoMethodError: undefined method `any?' for nil:NilClass> with backtrace:
         # ./lib/match_json/matchers/include_json.rb:58:in `block in array_included?'
         # ./lib/match_json/matchers/include_json.rb:57:in `each'
         # ./lib/match_json/matchers/include_json.rb:57:in `array_included?'
         # ./lib/match_json/matchers/include_json.rb:74:in `equal_value?'
         # ./lib/match_json/matchers/include_json.rb:44:in `block in hash_included?'
         # ./lib/match_json/matchers/include_json.rb:43:in `each'
         # ./lib/match_json/matchers/include_json.rb:43:in `hash_included?'
         # ./lib/match_json/matchers/include_json.rb:75:in `equal_value?'
         # ./lib/match_json/matchers/include_json.rb:34:in `json_included?'
         # ./lib/match_json/matchers/include_json.rb:20:in `block in matches?'
         # ./lib/match_json/matchers/include_json.rb:20:in `catch'
         # ./lib/match_json/matchers/include_json.rb:20:in `matches?'
         # ./spec/match_json/matchers_spec.rb:38:in `block (4 levels) in <top (required)>'
         # ./spec/match_json/matchers_spec.rb:37:in `block (3 levels) in <top (required)>'
     # ./spec/match_json/matchers_spec.rb:37:in `block (3 levels) in <top (required)>'
```