### PR TITLE
Improve failure message

### DIFF
--- a/lib/match_json/matchers/include_json.rb
+++ b/lib/match_json/matchers/include_json.rb
@@ -36,13 +36,13 @@ module MatchJson
 
       def hash_included?(actual, expected, nested, raise_error)
         if compared_different_types?(actual, expected)
-          @failure_message = %Q(Different types of compared elements:\n #{actual.class} for #{actual}\nand #{expected.class} for #{expected})
+          @failure_message = %Q(Different types of compared elements:\n #{actual.class} for #{actual.to_json}\nand #{expected.class} for #{expected.to_json})
           throw(:match, false)
         end
 
         expected.each do |key, value|
           if (!equal_value?(actual[key], value, "#{nested} > #{key}", raise_error))
-            @failure_message = %Q("#{key}"=>#{value} was not found in\n #{actual})
+            @failure_message = %Q("#{key}":#{value.to_json} was not found in\n #{actual.to_json})
 
             if raise_error
               throw(:match, false)
@@ -56,9 +56,9 @@ module MatchJson
       def array_included?(actual, expected, nested, raise_error)
         expected.each do |value|
           if actual.nil? || (!actual.any? { |actual_value| equal_value?(actual_value, value, nested, false) })
-            @failure_message = %Q("#{value}" was not found in\n )
-            @failure_message << %Q("#{nested}"=>) if !nested.empty?
-            @failure_message << "#{actual.nil? ? "nil" : actual}"
+            @failure_message = %Q("#{value.to_json}" was not found in\n )
+            @failure_message << %Q("#{nested}":) if !nested.empty?
+            @failure_message << "#{actual.to_json}"
 
             if raise_error
               throw(:match, false)

--- a/spec/match_json/matchers_spec.rb
+++ b/spec/match_json/matchers_spec.rb
@@ -8,35 +8,35 @@ describe "include_json" do
   it "fails when expected object is not included" do
     expect {
       expect(%Q({ "one": 1 })).to include_json(%Q({ "one": 2 }))
-    }.to fail_with(%Q("one"=>2 was not found in\n {"one"=>1}))
+    }.to fail_with(%Q("one":2 was not found in\n {"one":1}))
   end
 
   it 'passes when array is partially included' do
-    expect(%Q([1, 2, 3])).to include_json(%Q([3, 2]))
-    expect(%Q([1, 2, 3])).to include_json(%Q([1, 2, 3]))
+    expect(%Q([1,2,3])).to include_json(%Q([3,2]))
+    expect(%Q([1,2,3])).to include_json(%Q([1,2,3]))
   end
 
   it 'fails when there is no such array' do
     expect {
-      expect(%Q([1, 2, 3])).to include_json(%Q([3, 5]))
-    }.to fail_with(%Q("5" was not found in\n [1, 2, 3]))
+      expect(%Q([1,2,3])).to include_json(%Q([3,5]))
+    }.to fail_with(%Q("5" was not found in\n [1,2,3]))
   end
 
   context 'when object contains array' do
     it 'passes when array included' do
-      expect(%Q({ "array" : [1, 2, 3] })).to include_json(%Q({ "array" : [3, 2, 1] }))
+      expect(%Q({ "array" : [1,2,3] })).to include_json(%Q({ "array" : [3,2,1] }))
     end
 
     it 'fails with there is no such array' do
       expect {
-        expect(%Q({ "array" : [1, 2, 3] })).to include_json(%Q({ "array" : [5, 1] }))
-      }.to fail_with(%Q("5" was not found in\n " > array"=>[1, 2, 3]))
+        expect(%Q({ "array" : [1,2,3] })).to include_json(%Q({ "array" : [5,1] }))
+      }.to fail_with(%Q("5" was not found in\n " > array":[1,2,3]))
     end
 
     it 'fails with there is null instead of array' do
       expect {
         expect(%Q({ "array" : null })).to include_json(%Q({ "array" : [5] }))
-      }.to fail_with(%Q("5" was not found in\n " > array"=>nil))
+      }.to fail_with(%Q("5" was not found in\n " > array":null))
     end
   end
 
@@ -48,7 +48,7 @@ describe "include_json" do
     it 'fails when there is no such object in array' do
       expect {
         expect(%Q([ { "one": 1 }, { "two": 2 }])).to include_json(%Q([ { "one": 2 }]))
-      }.to fail_with(%Q(\"{"one"=>2}\" was not found in\n [{"one"=>1}, {"two"=>2}]))
+      }.to fail_with(%Q(\"{"one":2}\" was not found in\n [{"one":1},{"two":2}]))
     end
   end
 
@@ -56,7 +56,7 @@ describe "include_json" do
     it 'fails if object was not found' do
       expect {
         expect(%Q([ { "one": { "array": [1,2,3] } } ])).to include_json(%Q([ { "one": { "array": [1,2,3,4] } } ]))
-      }.to fail_with(%Q("{"one"=>{"array"=>[1, 2, 3, 4]}}" was not found in\n [{"one"=>{"array"=>[1, 2, 3]}}]))
+      }.to fail_with(%Q("{"one":{"array":[1,2,3,4]}}" was not found in\n [{"one":{"array":[1,2,3]}}]))
     end
   end
 
@@ -64,7 +64,7 @@ describe "include_json" do
     it 'fails with clean message' do
       expect {
         expect(%Q([ { "one": 1 } ])).to include_json(%Q({ "one": 1 }))
-      }.to fail_with(%Q(Different types of compared elements:\n Array for [{"one"=>1}]\nand Hash for {"one"=>1}))
+      }.to fail_with(%Q(Different types of compared elements:\n Array for [{"one":1}]\nand Hash for {"one":1}))
     end
   end
 
@@ -91,7 +91,10 @@ describe "include_json" do
 
       expect {
         expect(%Q({"one": "abcdef"})).to include_json(%Q({"one": "{id}"}))
-      }.to fail_with(%Q("one"=>{id} was not found in\n {"one"=>"abcdef"}))
+      }.to fail_with(%Q("one":"{id}" was not found in\n {"one":"abcdef"}))
+      expect {
+        expect(%Q({"one": true})).to include_json(%Q({"one": {id}}))
+      }.to fail_with(%Q("one":"{id}:non-string" was not found in\n {"one":true}))
     end
   end
 end


### PR DESCRIPTION
Since we dealing with json, I think failure message with json is more helpful.
Maybe you could add some failure message in README.md.
When I choose matcher,  the failure message is kinda priority feature.